### PR TITLE
Fix tag serialization for task creation

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -205,7 +205,9 @@ app.post('/api/tasks', async (req, res) => {
       data: {
         title,
         description: description || '',
-        tags:        tags || '',
+        tags:        typeof tags === 'object'
+                        ? JSON.stringify(tags)
+                        : tags || '',
         dueDate:     dueDate ? new Date(dueDate) : null,
         user:        { connect: { googleId: user.googleId } }
       }


### PR DESCRIPTION
## Summary
- ensure `tags` is stringified when creating a Task

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_688914dccbc88324b3a1ebe92ec375a9