### PR TITLE
Fix gemini model name and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 *.env
 frontend/node_modules/
 backend/node_modules/
+backend/generated/prisma

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,5 +1,0 @@
-node_modules
-# Keep environment variables out of version control
-.env
-
-/generated/prisma

--- a/backend/index.js
+++ b/backend/index.js
@@ -83,7 +83,7 @@ async function getTodaysEvents() {
 async function planAndScheduleTask(task) {
   try {
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-    const model = genAI.getGenerativeModel({ model: 'gemini-pro' });
+    const model = genAI.getGenerativeModel({ model: 'gemini-1.5-pro-latest' });
 
     let prompt = `You are an AI scheduling assistant. I have a task: "${task.title}".`;
     if (task.description) prompt += ` Details: ${task.description}.`;
@@ -105,7 +105,7 @@ async function planAndScheduleTask(task) {
 async function generateDailySummary() {
   try {
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-    const model = genAI.getGenerativeModel({ model: 'gemini-pro' });
+    const model = genAI.getGenerativeModel({ model: 'gemini-1.5-pro-latest' });
 
     const events = await getTodaysEvents();
     let summaryPrompt;

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,6 @@
     "@prisma/client": "^6.13.0",
     "axios": "^1.11.0",
     "cors": "^2.8.5",
-    "curl": "^0.1.4",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "googleapis": "^154.1.0",


### PR DESCRIPTION
## Summary
- use `gemini-1.5-pro-latest` model for scheduling and summary
- remove unused `curl` dependency
- rely on single `.gitignore`

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6889315fa1c48324b2609f9c9985b107